### PR TITLE
Set created date when uploading images

### DIFF
--- a/remote.go
+++ b/remote.go
@@ -172,7 +172,7 @@ func imageFromRemote(remote string, insecure bool) (*Image, error) {
 
 // ImageFromRepo gets an image from a repository.
 func (r *RegistryClient) ImageFromRepo(info *RepoInfo) (*Image, error) {
-	return imageFromDigest(r.ImageGetter(info), "manifest")
+	return imageFromDigest(r.ImageGetter(info), "manifest", nil)
 }
 
 // ImageGetter returns a function which gets an object from the


### PR DESCRIPTION
Smith doesn't store the created date in the image config so that it
will deterministically produce the same sha. Unfortunately, registries
do not look for any other annotations, so we set the Created date when
uploading the manifest. Fixes Issue #3