### PR TITLE
Support labels in smith.yaml

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,6 +33,7 @@ type ConfigDef struct {
 	Cmd        []string            `json:"cmd,omitempty"`
 	Dir        string              `json:"dir,omitempty"`
 	Env        []string            `json:"env,omitempty"`
+	Labels     map[string]string   `json:"labels,omitempty"`
 	Ports      map[string]struct{} `json:"ports,omitempty"`
 }
 

--- a/pack.go
+++ b/pack.go
@@ -146,6 +146,7 @@ func configFromDef(def *ConfigDef) *v1.Image {
 	config.Config.Env = def.Env
 	config.Config.WorkingDir = def.Dir
 	config.Config.ExposedPorts = def.Ports
+	config.Config.Labels = def.Labels
 	if def.Root {
 		config.Config.User = "0:0"
 	} else if def.User != "" {
@@ -422,6 +423,9 @@ func setDefaultsFromImage(def *ConfigDef, image *Image) {
 	}
 	if len(def.Ports) == 0 {
 		def.Ports = image.Config.Config.ExposedPorts
+	}
+	if len(def.Labels) == 0 {
+		def.Labels = image.Config.Config.Labels
 	}
 }
 


### PR DESCRIPTION
Some tools (like nvidia-docker) depend on labels being set in the image.
This patch supports labels in the smith.yaml. Labels are also inherited
from the parent image if they are not set in the yaml.