### PR TITLE
Update EPEL location for OL to point to the oracle EPEL clone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,7 @@ RUN make install
 
 FROM oraclelinux:7-slim
 
-RUN rpm -i http://dl.fedoraproject.org/pub/epel/7/x86_64/Packages/e/epel-release-7-11.noarch.rpm
-
-RUN yum install -y pigz mock && yum clean all
+RUN yum install -y --enablerepo ol7_developer_EPEL pigz mock && yum clean all
 
 ADD etc /etc
 


### PR DESCRIPTION
Oracle Linux has its own EPEL repo available and the yum.repo file has
an entry but it's disabled. No need to install epel-release RPMs and
separately download from fedoraproject.org

Signed-off-by: Wim Coekaerts <wim.coekaerts@oracle.com>